### PR TITLE
Add cache directory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ uvicorn backend.main:app --reload
 
 Available endpoints:
 
+- `/config/cache_path` – POST a directory path to configure the cache.
 - `/schema` – returns the YAML schema.
 - `/sessions` – lists sessions from the cached CSV.
 - `/telemetry` – returns telemetry data for a session.
+
+Call `/config/cache_path` before other endpoints so the server knows where to
+find `fastf1.duckdb` and `session_index.csv`.


### PR DESCRIPTION
## Summary
- add `/config/cache_path` endpoint for cache setup
- check for configured cache in `/sessions` and `/telemetry`
- document cache configuration in README

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687cfae883888331be9a1003b7bd5805