### PR TITLE
Point /sessions at built-in CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Available endpoints:
 
 - `/config/cache_path` – POST a directory path to configure the cache.
 - `/schema` – returns the YAML schema.
-- `/sessions` – lists sessions from the cached CSV.
+- `/sessions` – lists sessions from `session_index.csv`.
 - `/telemetry` – returns telemetry data for a session.
 
-Call `/config/cache_path` before other endpoints so the server knows where to
-find `fastf1.duckdb` and `session_index.csv`.
+Call `/config/cache_path` before using `/telemetry` so the server knows where to
+find `fastf1.duckdb`. `/sessions` reads from the built-in `session_index.csv` by
+default.

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,14 +5,15 @@ import csv
 import os
 import yaml
 import json
+from pathlib import Path
 
-BASE_DIR = os.path.dirname(__file__)
-SCHEMA_PATH = os.path.join(os.path.dirname(BASE_DIR), "schema.yaml")
+BASE_DIR = Path(__file__).resolve().parent
+SCHEMA_PATH = BASE_DIR.parent / "schema.yaml"
 
 # Cache configuration; set via /config/cache_path
 CACHE_DIR = None
 DB_PATH = None
-INDEX_PATH = None
+INDEX_PATH = BASE_DIR.parent / "session_index.csv"
 
 app = FastAPI(title="FastF1-browser API")
 
@@ -49,10 +50,8 @@ def get_schema():
 
 @app.get("/sessions")
 def list_sessions():
-    if CACHE_DIR is None:
-        raise HTTPException(400, "Cache directory not configured")
     if not os.path.isfile(INDEX_PATH):
-        raise HTTPException(500, "session_index.csv missing in cache directory")
+        raise HTTPException(500, "session_index.csv missing")
     with open(INDEX_PATH, newline="") as csvfile:
         return list(csv.DictReader(csvfile))
 


### PR DESCRIPTION
## Summary
- load schema and session index via `Path`
- default `INDEX_PATH` to repo's `session_index.csv`
- `/sessions` now reads sessions from that CSV
- clarify docs about default session index

## Testing
- `python -m py_compile backend/main.py`
- `python -m py_compile backend/scripts/prepare_dummy_db.py backend/scripts/reset_db.py`


------
https://chatgpt.com/codex/tasks/task_e_687cfb71dc4c8331b8474e4781394d1b