### PR TITLE
Fix dummy DB creation message

### DIFF
--- a/backend/scripts/prepare_dummy_db.py
+++ b/backend/scripts/prepare_dummy_db.py
@@ -10,6 +10,7 @@ def create_dummy_db(db_path: Path = Path(__file__).resolve().parent.parent / "da
     con.close()
 
 if __name__ == "__main__":
+    db_path = create_dummy_db.__defaults__[0]
     create_dummy_db()
-    print(f"Created dummy DB at {create_dummy_db.__defaults__[0]}")
+    print(f"Created dummy DB at {db_path}")
 


### PR DESCRIPTION
## Summary
- print the database path directly in `prepare_dummy_db.py`

## Testing
- `python -m py_compile backend/scripts/prepare_dummy_db.py`
- `python -m py_compile backend/scripts/reset_db.py backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_687cfd6f7e3c83319aa5a5e08a355e1e