### PR TITLE
Update SessionAnalyser dropdowns

### DIFF
--- a/frontend/src/components/SessionAnalyser.tsx
+++ b/frontend/src/components/SessionAnalyser.tsx
@@ -3,10 +3,10 @@ import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
 
 interface SessionInfo {
-  Season: string;
-  Round: string;
-  Session: string;
-  SessionID: string;
+  year: string;
+  event_name: string;
+  session_type: string;
+  session_id: string;
 }
 
 export default function SessionAnalyser() {
@@ -19,12 +19,12 @@ export default function SessionAnalyser() {
   });
 
   const [year, setYear] = useState('');
-  const [race, setRace] = useState('');
+  const [eventName, setEventName] = useState('');
   const [sessionId, setSessionId] = useState('');
 
-  const years = Array.from(new Set(sessions?.map(s => s.Season)));
-  const races = sessions?.filter(s => s.Season === year);
-  const sessionOpts = races?.filter(r => r.Round === race);
+  const years = Array.from(new Set(sessions?.map(s => s.year)));
+  const events = sessions?.filter(s => s.year === year);
+  const sessionOpts = events?.filter(e => e.event_name === eventName);
 
   return (
     <div>
@@ -35,22 +35,22 @@ export default function SessionAnalyser() {
         ))}
       </select>
 
-      <select value={race} onChange={e => setRace(e.target.value)} disabled={!year}>
-        <option value="">Race</option>
-        {races?.map(r => (
-          <option key={r.Round}>{r.Round}</option>
+      <select value={eventName} onChange={e => setEventName(e.target.value)} disabled={!year}>
+        <option value="">Event</option>
+        {events?.map(e => (
+          <option key={e.event_name}>{e.event_name}</option>
         ))}
       </select>
 
       <select
         value={sessionId}
         onChange={e => setSessionId(e.target.value)}
-        disabled={!race}
+        disabled={!eventName}
       >
         <option value="">Session</option>
         {sessionOpts?.map(s => (
-          <option key={s.SessionID} value={s.SessionID}>
-            {s.Session}
+          <option key={s.session_id} value={s.session_id}>
+            {s.session_type}
           </option>
         ))}
       </select>


### PR DESCRIPTION
## Summary
- sync SessionAnalyser field names with the CSV
- use these fields in dropdown logic

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687d02497c28833187bccef7d81287b4