### PR TITLE
Update README with cache build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ To Interact with F1 data cached using FastF1
 ## Scripts
 - `backend/scripts/prepare_dummy_db.py` generates a small dummy DuckDB for local testing.
 - `backend/scripts/reset_db.py` clears any in-memory DB state.
+- `backend/scripts/build_session_index.py` builds the `session_index.csv` cache index.
 
 Backend data and cache directories are ignored via `.gitignore`.
 
@@ -35,14 +36,18 @@ database if you don't already have one.
 
 Available endpoints:
 
-- `/config/cache_path` – POST a directory path to configure the cache.
+- `/config/cache_path` – POST a directory path to configure the cache. This call
+  runs `backend/scripts/build_session_index.py` which generates
+  `session_index.csv` from any `.ff1pkl` files in the directory.
 - `/schema` – returns the YAML schema.
 - `/sessions` – lists sessions from `session_index.csv`.
 - `/telemetry` – returns telemetry data for a session.
 
 Call `/config/cache_path` before using `/telemetry` so the server knows where to
-find `fastf1.duckdb`. `/sessions` reads from the built-in `session_index.csv` by
-default.
+find `fastf1.duckdb`. The invoked script scans the given folder for `.ff1pkl`
+files and writes the discovered sessions to `session_index.csv`. If no such
+cache files exist, the endpoint fails with an error. `/sessions` reads from the
+built-in `session_index.csv` by default.
 
 ## Frontend
 


### PR DESCRIPTION
## Summary
- document build_session_index.py in Scripts section
- note that /config/cache_path triggers the script
- explain how the script populates session_index.csv and when errors occur

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d0581f96883319c5f2cb108eb62dd