### PR TITLE
Add cache endpoint tests with index generation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ import os
 import yaml
 import json
 from pathlib import Path
+import re
 
 BASE_DIR = Path(__file__).resolve().parent
 SCHEMA_PATH = BASE_DIR.parent / "schema.yaml"
@@ -16,6 +17,36 @@ DB_PATH = None
 INDEX_PATH = BASE_DIR.parent / "session_index.csv"
 
 app = FastAPI(title="FastF1-browser API")
+
+
+def _write_session_index(index_path: str, pkl_files):
+    """Create a minimal ``session_index.csv`` from ``*.ff1pkl`` files."""
+    header = ["session_id", "year", "event_name", "event_date", "session_type", "sid"]
+    pattern = re.compile(
+        r"(?P<year>\d{4})_(?P<event_date>\d{4}-\d{2}-\d{2})_(?P<event_name>.*)_(?P<sid>FP1|FP2|FP3|Q|R)$"
+    )
+    type_map = {
+        "FP1": "Practice 1",
+        "FP2": "Practice 2",
+        "FP3": "Practice 3",
+        "Q": "Qualifying",
+        "R": "Race",
+    }
+
+    with open(index_path, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(header)
+        for pkl in pkl_files:
+            stem = pkl.stem
+            m = pattern.match(stem)
+            if not m:
+                continue
+            year = m.group("year")
+            event_date = m.group("event_date")
+            event_name = m.group("event_name").replace("_", " ")
+            sid = m.group("sid")
+            session_type = type_map.get(sid, sid)
+            writer.writerow([stem, year, event_name, event_date, session_type, sid])
 
 app.add_middleware(
     CORSMiddleware,
@@ -33,6 +64,17 @@ def set_cache_path(path: str):
         raise HTTPException(400, "Invalid cache directory")
     db_path = os.path.join(path, "fastf1.duckdb")
     index_path = os.path.join(path, "session_index.csv")
+
+    # If the session index does not exist, attempt to create it from any
+    # ``*.ff1pkl`` files found in the cache directory. This mirrors how a real
+    # FastF1 cache would be initialised.
+    if not os.path.isfile(index_path):
+        pkl_files = list(Path(path).glob("*.ff1pkl"))
+        if pkl_files:
+            _write_session_index(index_path, pkl_files)
+        else:
+            raise HTTPException(400, "Cache directory missing required files")
+
     if not os.path.isfile(db_path) or not os.path.isfile(index_path):
         raise HTTPException(400, "Cache directory missing required files")
     global CACHE_DIR, DB_PATH, INDEX_PATH

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -1,0 +1,38 @@
+import csv
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from backend.main import app
+
+
+def test_cache_path_creates_index(tmp_path):
+    # Prepare dummy cache directory with a duckdb file and a single ff1pkl file
+    cache_dir = tmp_path
+    (cache_dir / "fastf1.duckdb").write_text("")
+    pkl_name = "2018_2018-03-25_Australian_Grand_Prix_FP1.ff1pkl"
+    (cache_dir / pkl_name).write_text("")
+
+    client = TestClient(app)
+    response = client.post("/config/cache_path", params={"path": str(cache_dir)})
+    assert response.status_code == 200
+
+    index_file = cache_dir / "session_index.csv"
+    assert index_file.is_file()
+
+    with index_file.open() as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == pkl_name[:-7]
+    assert rows[0]["sid"] == "FP1"
+
+
+def test_cache_path_error_no_pickles(tmp_path):
+    cache_dir = tmp_path
+    (cache_dir / "fastf1.duckdb").write_text("")
+    client = TestClient(app)
+    response = client.post("/config/cache_path", params={"path": str(cache_dir)})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- support generating `session_index.csv` from `.ff1pkl` files when configuring a cache path
- test `/config/cache_path` success with temporary cache
- test error when cache lacks `.ff1pkl` files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d05af684883318f757c349906567f