### PR TITLE
Add Launch.bat convenience script

### DIFF
--- a/Launch.bat
+++ b/Launch.bat
@@ -1,0 +1,2 @@
+@echo off
+docker compose up --build

--- a/README.md
+++ b/README.md
@@ -76,3 +76,8 @@ Run the TypeScript linter from inside `frontend/`:
 cd frontend
 npm run lint
 ```
+
+## Docker Compose
+
+Double-click `Launch.bat` to start both services via Docker Compose.
+


### PR DESCRIPTION
## Summary
- add a `Launch.bat` helper to start docker-compose
- document how to use it in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d18318228833192779d69d2583d4e