### PR TITLE
Fix startup flow and port config

### DIFF
--- a/Launch.bat
+++ b/Launch.bat
@@ -1,2 +1,9 @@
 @echo off
-docker compose up --build
+REM Build and start containers detached
+docker compose up -d --build
+
+for /L %%i in (3,-1,1) do (
+    echo Opening browser in %%i...
+    timeout /t 1 > NUL
+)
+start http://localhost:5173

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,11 @@ services:
   backend:
     build: .
     ports:
-      - "8000:8000"
+      - "8001:8000"
   frontend:
     build: ./frontend
+    environment:
+      - VITE_BACKEND_URL=http://backend:8000
     ports:
       - "5173:5173"
     depends_on:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SessionAnalyser from './components/SessionAnalyser';
+import CacheConfigurator from './components/CacheConfigurator';
 
 export default function App() {
+  const [configured, setConfigured] = useState(false);
+
   return (
     <div>
       <h1>FastF1 Browser</h1>
-      <SessionAnalyser />
+      {configured ? (
+        <SessionAnalyser />
+      ) : (
+        <CacheConfigurator onConfigured={() => setConfigured(true)} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/CacheConfigurator.tsx
+++ b/frontend/src/components/CacheConfigurator.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useMutation } from '@tanstack/react-query';
+
+interface Props {
+  onConfigured: () => void;
+}
+
+const CacheConfigurator: React.FC<Props> = ({ onConfigured }) => {
+  const [path, setPath] = useState('');
+  const mutation = useMutation({
+    mutationFn: async () => {
+      await axios.post('/config/cache_path', null, { params: { path } });
+    },
+    onSuccess: () => {
+      onConfigured();
+    },
+  });
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <input
+          type="text"
+          value={path}
+          onChange={e => setPath(e.target.value)}
+          placeholder="Cache directory path"
+        />
+        <button onClick={() => mutation.mutate()} disabled={!path || mutation.isLoading}>
+          Go
+        </button>
+      </div>
+      {mutation.isError && (
+        <div className="text-red-600">Failed: {(mutation.error as Error).message}</div>
+      )}
+    </div>
+  );
+};
+
+export default CacheConfigurator;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -3,3 +3,4 @@ export { default as SessionAnalyser } from './SessionAnalyser';
 export { default as LapTimeScatter } from './LapTimeScatter';
 export { default as WeatherLine } from './WeatherLine';
 export { default as PaceVsTimeScatter } from './PaceVsTimeScatter';
+export { default as CacheConfigurator } from './CacheConfigurator';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,16 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const backendUrl = process.env.VITE_BACKEND_URL || 'http://localhost:8000';
+
 export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/sessions': 'http://localhost:8000',
-      '/session': 'http://localhost:8000',
+      '/sessions': backendUrl,
+      '/config': backendUrl,
+      '/telemetry': backendUrl,
+      '/schema': backendUrl,
     },
   },
 });


### PR DESCRIPTION
## Summary
- expose backend on port 8001 and pass backend URL to frontend
- open the frontend automatically after compose starts
- require cache path before showing session analyser
- configure Vite proxy via environment variable

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d1ef22ebc8331af1ccaf70d855a7f