### PR TITLE
Expose index build count

### DIFF
--- a/frontend/src/components/CacheConfigurator.tsx
+++ b/frontend/src/components/CacheConfigurator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import axios from 'axios';
 import { useMutation } from '@tanstack/react-query';
 
@@ -8,14 +8,33 @@ interface Props {
 
 const CacheConfigurator: React.FC<Props> = ({ onConfigured }) => {
   const [path, setPath] = useState('');
+  const [success, setSuccess] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const mutation = useMutation({
     mutationFn: async () => {
-      await axios.post('/config/cache_path', null, { params: { path } });
+      const { data } = await axios.post('/config/cache_path', null, { params: { path } });
+      return data as { added: number };
     },
-    onSuccess: () => {
-      onConfigured();
+    onSuccess: data => {
+      setSuccess(`Success: added ${data.added} records`);
+      setTimeout(() => onConfigured(), 1000);
     },
   });
+
+  function handleBrowse() {
+    fileInputRef.current?.click();
+  }
+
+  function handleDirSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files;
+    if (files && files.length) {
+      const f = files[0] as File & { path?: string; webkitRelativePath?: string };
+      if (f.path) {
+        const rel = f.webkitRelativePath || '';
+        setPath(f.path.slice(0, f.path.length - rel.length));
+      }
+    }
+  }
 
   return (
     <div className="space-y-2">
@@ -26,10 +45,21 @@ const CacheConfigurator: React.FC<Props> = ({ onConfigured }) => {
           onChange={e => setPath(e.target.value)}
           placeholder="Cache directory path"
         />
-        <button onClick={() => mutation.mutate()} disabled={!path || mutation.isLoading}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          style={{ display: 'none' }}
+          webkitdirectory="true"
+          onChange={handleDirSelected}
+        />
+        <button type="button" onClick={handleBrowse} className="ml-1">
+          Browse…
+        </button>
+        <button onClick={() => mutation.mutate()} disabled={!path || mutation.isLoading} className="ml-1">
           Go
         </button>
       </div>
+      {success && <div className="text-green-700">{success}</div>}
       {mutation.isError && (
         <div className="text-red-600">Failed: {(mutation.error as Error).message}</div>
       )}

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -18,6 +18,7 @@ def test_cache_path_creates_index(tmp_path):
     client = TestClient(app)
     response = client.post("/config/cache_path", params={"path": str(cache_dir)})
     assert response.status_code == 200
+    assert response.json()["added"] == 1
 
     index_file = cache_dir / "session_index.csv"
     assert index_file.is_file()


### PR DESCRIPTION
## Summary
- return number of newly indexed sessions from `/config/cache_path`
- show index build result and optional folder picker in CacheConfigurator
- test the new `added` response field

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d225391c48331b157aa72086ac1be