### PR TITLE
Improve cache path selection

### DIFF
--- a/frontend/src/components/CacheConfigurator.tsx
+++ b/frontend/src/components/CacheConfigurator.tsx
@@ -9,6 +9,7 @@ interface Props {
 const CacheConfigurator: React.FC<Props> = ({ onConfigured }) => {
   const [path, setPath] = useState('');
   const [success, setSuccess] = useState('');
+  const [errorDetail, setErrorDetail] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const mutation = useMutation({
     mutationFn: async () => {
@@ -18,6 +19,16 @@ const CacheConfigurator: React.FC<Props> = ({ onConfigured }) => {
     onSuccess: data => {
       setSuccess(`Success: added ${data.added} records`);
       setTimeout(() => onConfigured(), 1000);
+    },
+    onError: err => {
+      // eslint-disable-next-line no-console
+      console.error('Cache configuration failed', err);
+      if (axios.isAxiosError(err)) {
+        const detail = err.response?.data?.detail;
+        if (typeof detail === 'string') {
+          setErrorDetail(detail);
+        }
+      }
     },
   });
 
@@ -49,7 +60,8 @@ const CacheConfigurator: React.FC<Props> = ({ onConfigured }) => {
           ref={fileInputRef}
           type="file"
           style={{ display: 'none' }}
-          webkitdirectory="true"
+          directory=""
+          webkitdirectory=""
           onChange={handleDirSelected}
         />
         <button type="button" onClick={handleBrowse} className="ml-1">
@@ -61,7 +73,10 @@ const CacheConfigurator: React.FC<Props> = ({ onConfigured }) => {
       </div>
       {success && <div className="text-green-700">{success}</div>}
       {mutation.isError && (
-        <div className="text-red-600">Failed: {(mutation.error as Error).message}</div>
+        <div className="text-red-600">
+          Failed: {(mutation.error as Error).message}
+          {errorDetail && <div>{errorDetail}</div>}
+        </div>
       )}
     </div>
   );

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi>=0.111,<1.0
 uvicorn>=0.25,<0.36
 duckdb>=1.3,<2.0
 pytest>=7
+PyYAML>=6
+httpx


### PR DESCRIPTION
## Summary
- handle directory selection correctly in CacheConfigurator
- surface backend error details in CacheConfigurator
- log errors to console for easier debugging
- add missing dependencies for backend tests

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2629fa2c8331a77c018c53523647