### PR TITLE
Update Frontend cache path instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ npm install
 npm run dev
 ```
 
+Copy the path to your FastF1 cache directory from Windows Explorer (spaces and
+all) and paste it into the UI's **Cache directory path** field. The "Browse…"
+button has been removed, so the path must be entered manually.
+
 Run `npm run lint` to check TypeScript code.
 
 ## Testing


### PR DESCRIPTION
## Summary
- explain how to manually enter cache path for frontend
- note Browse… button removal

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_687e0113b68c833195a30dd4b7adfa73